### PR TITLE
[kube-state-metrics] Allow to disable CRS ConfigMap creation

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.33.1
+version: 5.34.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.15.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -173,3 +173,14 @@ The image to use for kubeRBACProxy
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+The name of the ConfigMap for the customResourceState config.
+*/}}
+{{- define "kube-state-metrics.crsConfigMapName" -}}
+  {{- if ne .Values.customResourceState.name "" }}
+    {{- .Values.customResourceState.name }}
+  {{- else }}
+    {{- template "kube-state-metrics.fullname" . }}-customresourcestate-config
+  {{- end }}
+{{- end }}

--- a/charts/kube-state-metrics/templates/crs-configmap.yaml
+++ b/charts/kube-state-metrics/templates/crs-configmap.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.customResourceState.enabled}}
+{{- if and .Values.customResourceState.enabled .Values.customResourceState.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "kube-state-metrics.fullname" . }}-customresourcestate-config
+  name: {{ template "kube-state-metrics.crsConfigMapName" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     {{- include "kube-state-metrics.labels" . | indent 4 }}
@@ -11,6 +11,6 @@ metadata:
     {{ toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 data:
-  config.yaml: |
+  {{ .Values.customResourceState.key }}: |
     {{- toYaml .Values.customResourceState.config | nindent 4 }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.customResourceState.enabled }}
-        - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
+        - --custom-resource-state-config-file=/etc/customresourcestate/{{ .Values.customResourceState.key }}
         {{- end }}
         {{- if or (.Values.kubeconfig.enabled) (.Values.customResourceState.enabled) (.Values.volumeMounts) }}
         volumeMounts:
@@ -362,7 +362,7 @@ spec:
       {{- if .Values.customResourceState.enabled}}
         - name: customresourcestate-config
           configMap:
-            name: {{ template "kube-state-metrics.fullname" . }}-customresourcestate-config
+            name: {{ template "kube-state-metrics.crsConfigMapName" . }}
       {{- end }}
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -450,8 +450,19 @@ kubeconfig:
 
 # Enabling support for customResourceState, will create a configMap including your config that will be read from kube-state-metrics
 customResourceState:
+  # Whether to enable support for CustomResourceStateMetrics.
   enabled: false
-  # Add (Cluster)Role permissions to list/watch the customResources defined in the config to rbac.extraRules
+
+  # Whether to create the ConfigMap that holds the config.
+  create: true
+
+  # Name of the ConfigMap that holds the config. If empty, name will be generated based on the release name.
+  name: ""
+
+  # ConfigMap key that holds the config.
+  key: config.yaml
+
+  # Definition of the CustomResourceStateMetrics. Add (Cluster)Role permissions to list/watch the resources defined in the config to rbac.extraRules.
   config: {}
 
 # Enable only the release namespace for collecting resources. By default all namespaces are collected.


### PR DESCRIPTION
This PR allows to disable the creation of the `ConfigMap` used for the `CustomResourceStateMetric` definition. It also allows to configire the `ConfigMap` key under which the `CustomResourceStateMetric` definition exists. This is very useful if the `ConfigMap` is created through other means.